### PR TITLE
MaxEnergyValue after LevelUp fixed + base stats

### DIFF
--- a/Models/Mage.cs
+++ b/Models/Mage.cs
@@ -10,7 +10,7 @@ namespace JDR.Models
             LevelProgression progression,
             int level = 1,
             int experienceValue = 0,
-            int energyValue = 40,
+            int energyValue = 13,
             int armorValue = 2,
             int bonusDamage = 0,
             int criticalChance = 2,
@@ -32,23 +32,34 @@ namespace JDR.Models
         // Initializes stats
         private void InitializeStats()
         {
-            Stamina = StatsCalculator.CalculateStat(2, 1.2, Level);
+            Stamina = StatsCalculator.CalculateStat(8, 1.27, Level);
             Strength = StatsCalculator.CalculateStat(1, 1.05, Level);
-            Intellect = StatsCalculator.CalculateStat(4, 1.25, Level);
+            Intellect = StatsCalculator.CalculateStat(4, 1.27, Level);
             Agility = StatsCalculator.CalculateStat(1, 1.05, Level);
-            Spirit = StatsCalculator.CalculateStat(3, 1.15, Level);
-            CurrentHealthValue = Stamina * 10;
-            MaxHealthValue = CurrentHealthValue;
-            CurrentEnergyValue = (int)Math.Round(CurrentEnergyValue * (Spirit * 0.65));
-            MaxEnergyValue = CurrentEnergyValue;
-            AttackValue = (int)Math.Round(Intellect * 1.8);
+            Spirit = StatsCalculator.CalculateStat(7, 1.27, Level);
+            MaxHealthValue = Stamina * 4;
+            MaxEnergyValue = (int)Math.Floor(13 * Spirit * 0.6);
+            AttackValue = (int)Math.Floor(Intellect * 1.8);
+            if (Level == 1) // First initialization
+            {
+                CurrentHealthValue = MaxHealthValue;
+                CurrentEnergyValue = MaxEnergyValue;
+            }
         }
     
         // Overrides the base LevelUp method to update the stats
         protected override void LevelUp()
         {
             base.LevelUp();
+            int previousMaxEnergyValue = MaxEnergyValue;
             InitializeStats(); // Updates stats after level up
+            
+            // Adjust CurrentEnergyValue proportionally to the increase in MaxEnergyValue
+            CurrentEnergyValue += MaxEnergyValue - previousMaxEnergyValue;
+
+            // Ensure CurrentEnergyValue does not exceed MaxEnergyValue
+            if (CurrentEnergyValue > MaxEnergyValue)
+                CurrentEnergyValue = MaxEnergyValue;
         }
     
         // The base attack

--- a/Models/StatsCalculator.cs
+++ b/Models/StatsCalculator.cs
@@ -11,7 +11,7 @@ namespace JDR.Models
             int bonus = (level / bonusInterval) * bonusAmount;
 
             // Diminishing returns to avoid excessive value growth
-            double diminishingFactor = 1 - (level / 100.0);
+            double diminishingFactor = Math.Max(1 - (level / 100.0), 0.5);
 
             // Applies diminishing factor
             statValue *= diminishingFactor;

--- a/Pages/Home.razor
+++ b/Pages/Home.razor
@@ -27,9 +27,9 @@
                     <p><strong>Armor:</strong> @hero?.ArmorValue</p>
                     <p><strong>Attack:</strong> @hero?.AttackValue</p>
                     <p><strong>Bonus Dmg:</strong> +@hero?.BonusDamage</p>
-                    <p><strong>Crit Chance:</strong> @hero?.AttackValue%</p>
-                    <p><strong>Haste:</strong> @hero?.AttackValue%</p>
-                    <p><strong>Dodge:</strong> @hero?.AttackValue%</p>
+                    <p><strong>Crit Chance:</strong> @hero?.CriticalChance%</p>
+                    <p><strong>Haste:</strong> @hero?.HasteValue%</p>
+                    <p><strong>Dodge:</strong> @hero?.DodgeRating%</p>
                 </div>
             </div>
 

--- a/Pages/MapComponent.razor.css
+++ b/Pages/MapComponent.razor.css
@@ -18,7 +18,7 @@
 
 @keyframes heroSpriteAnimation {
     from {
-        background-position: 0px;
+        background-position: 0;
     }
 
     to {


### PR DESCRIPTION
- Fixed the method to calculate MaxEnergyValue after the LevelUp method is called to avoid miscalculation,
- Fixed a bug where AttackValue was displayed instead of CriticalChance, HasteValue and DodgeRating in the hero-stats panel,
- Balanced heros & monsters base stats,
- Balanced StatsCalculator when level up.

Closes #28 